### PR TITLE
Implement orchestrator auto-run loop

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 An autonomous, agent-based system that plans, writes, edits, illustrates and publishes long-form, SEO-optimised articles directly to WordPress.
 
-> **Status:** Sprint 2 in progress – new `site_scaffold_agent` introduced and orchestrator auto‑run features under active development.
+> **Status:** Sprint 2 in progress – `site_scaffold_agent` ready and orchestrator auto‑run loop implemented.
 
 ---
 

--- a/tests/unit/test_orchestrator_autorun.py
+++ b/tests/unit/test_orchestrator_autorun.py
@@ -1,0 +1,22 @@
+import sys
+import os
+import unittest
+from types import SimpleNamespace
+
+# Ensure parent path
+sys.path.append(
+    os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+)
+
+from orchestrator import get_next_agent
+
+
+class TestOrchestratorAutoRun(unittest.TestCase):
+    def test_get_next_agent(self):
+        self.assertEqual(get_next_agent("seo-agent"), "research-agent")
+        self.assertEqual(get_next_agent("image-generator-agent"), "wordpress-publisher-agent")
+        self.assertIsNone(get_next_agent("wordpress-publisher-agent"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- implement `NEXT_AGENT_MAP` and helper `get_next_agent`
- create `process_task` for queued tasks
- add looping mode via `--loop` flag
- update README status
- add unit test for `get_next_agent`

## Testing
- `./run_tests.sh` *(fails: could not install deps, formatters fail)*

------
https://chatgpt.com/codex/tasks/task_e_687e3aad3770832583386ba60c0dcff5