### PR TITLE
Implement basic RBAC and auth middleware

### DIFF
--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -13,6 +13,7 @@
     "@radix-ui/react-dropdown-menu": "^2.1.15",
     "@radix-ui/react-toast": "^1.2.14",
     "@supabase/supabase-js": "^2.52.0",
+    "@supabase/auth-helpers-nextjs": "^0.8.0",
     "date-fns": "^4.1.0",
     "next": "15.4.2",
     "react": "19.1.0",

--- a/dashboard/src/app/layout.tsx
+++ b/dashboard/src/app/layout.tsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 import { FiHome, FiFileText, FiTarget, FiSettings, FiMenu, FiX } from "react-icons/fi";
 import Image from "next/image";
 import { useState, useEffect } from "react";
+import supabase from "@/lib/supabase";
 import { Providers } from "./providers";
 
 const inter = Inter({ subsets: ["latin"] });
@@ -33,10 +34,29 @@ function SidebarLink({ href, icon, children, isMobileMenuOpen, setMobileMenuOpen
   );
 }
 
-function Sidebar({ isMobileMenuOpen, setMobileMenuOpen }: { 
+function Sidebar({ isMobileMenuOpen, setMobileMenuOpen }: {
   isMobileMenuOpen: boolean;
   setMobileMenuOpen: (open: boolean) => void;
 }) {
+  const [role, setRole] = useState<string | null>(null);
+
+  useEffect(() => {
+    async function fetchRole() {
+      const {
+        data: { user },
+      } = await supabase.auth.getUser();
+      if (user) {
+        const { data: profile } = await supabase
+          .from('user_profiles')
+          .select('role')
+          .eq('id', user.id)
+          .single();
+        setRole(profile?.role || 'editor');
+      }
+    }
+    fetchRole();
+  }, []);
+
   return (
     <>
       {/* Mobile overlay */}
@@ -86,9 +106,16 @@ function Sidebar({ isMobileMenuOpen, setMobileMenuOpen }: {
             <SidebarLink href="/plans" icon={<FiTarget />} isMobileMenuOpen={isMobileMenuOpen} setMobileMenuOpen={setMobileMenuOpen}>
               Strategic Plans
             </SidebarLink>
-            <SidebarLink href="/settings" icon={<FiSettings />} isMobileMenuOpen={isMobileMenuOpen} setMobileMenuOpen={setMobileMenuOpen}>
-              Settings
-            </SidebarLink>
+            {role === 'admin' && (
+              <SidebarLink
+                href="/settings"
+                icon={<FiSettings />}
+                isMobileMenuOpen={isMobileMenuOpen}
+                setMobileMenuOpen={setMobileMenuOpen}
+              >
+                Settings
+              </SidebarLink>
+            )}
           </nav>
           
           {/* Footer */}

--- a/dashboard/src/app/login/page.tsx
+++ b/dashboard/src/app/login/page.tsx
@@ -1,0 +1,41 @@
+'use client';
+import { useState } from 'react';
+import supabase from '@/lib/supabase';
+
+export default function LoginPage() {
+  const [email, setEmail] = useState('');
+  const [message, setMessage] = useState('');
+
+  const handleLogin = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const { error } = await supabase.auth.signInWithOtp({ email });
+    if (error) {
+      setMessage('Failed to send magic link');
+    } else {
+      setMessage('Check your email for the magic link');
+    }
+  };
+
+  return (
+    <div className="max-w-md mx-auto mt-20 space-y-4">
+      <h1 className="text-2xl font-bold">Login</h1>
+      <form onSubmit={handleLogin} className="space-y-4">
+        <input
+          type="email"
+          required
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          className="w-full border px-3 py-2 rounded"
+          placeholder="you@example.com"
+        />
+        <button
+          type="submit"
+          className="w-full bg-blue-600 text-white py-2 rounded"
+        >
+          Send Magic Link
+        </button>
+      </form>
+      {message && <p>{message}</p>}
+    </div>
+  );
+}

--- a/dashboard/src/lib/supabase.ts
+++ b/dashboard/src/lib/supabase.ts
@@ -1,0 +1,8 @@
+import { createClient } from '@supabase/supabase-js';
+
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL || '';
+const supabaseKey = process.env.NEXT_PUBLIC_SUPABASE_KEY || '';
+
+const supabase = createClient(supabaseUrl, supabaseKey);
+
+export default supabase;

--- a/dashboard/src/middleware.ts
+++ b/dashboard/src/middleware.ts
@@ -1,0 +1,37 @@
+import { NextResponse } from 'next/server';
+import type { NextRequest } from 'next/server';
+import { createMiddlewareClient } from '@supabase/auth-helpers-nextjs';
+
+export async function middleware(request: NextRequest) {
+  const response = NextResponse.next();
+  const supabase = createMiddlewareClient({ req: request, res: response });
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user && request.nextUrl.pathname !== '/login') {
+    return NextResponse.redirect(new URL('/login', request.url));
+  }
+
+  if (user) {
+    const { data: profile } = await supabase
+      .from('user_profiles')
+      .select('role')
+      .eq('id', user.id)
+      .single();
+
+    if (
+      request.nextUrl.pathname.startsWith('/settings') &&
+      profile?.role !== 'admin'
+    ) {
+      return NextResponse.redirect(new URL('/', request.url));
+    }
+  }
+
+  return response;
+}
+
+export const config = {
+  matcher: ['/((?!api|_next/static|_next/image|favicon.ico).*)'],
+};

--- a/tests/unit/test_dashboard_auth.py
+++ b/tests/unit/test_dashboard_auth.py
@@ -1,0 +1,22 @@
+import os
+import unittest
+
+
+class TestDashboardAuth(unittest.TestCase):
+    def test_middleware_exists(self):
+        path = os.path.join('dashboard', 'src', 'middleware.ts')
+        self.assertTrue(os.path.exists(path), 'middleware.ts should exist')
+        with open(path, 'r') as f:
+            content = f.read()
+        self.assertIn('createMiddlewareClient', content)
+        self.assertIn("'/login'", content)
+
+    def test_settings_link_restricted(self):
+        path = os.path.join('dashboard', 'src', 'app', 'layout.tsx')
+        with open(path, 'r') as f:
+            layout = f.read()
+        self.assertIn("role === 'admin'", layout)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- set up Supabase client for dashboard
- add login page with magic link flow
- restrict routes via middleware
- hide Settings nav item for non-admins
- add unit tests checking auth scaffolding

## Testing
- `./run_tests.sh` *(fails: Could not install dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_687e46d04428832597114d4b362c52f7