### PR TITLE
Add auth bypass dev flag

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,3 +25,4 @@ UNSPLASH_API_KEY=your_unsplash_api_key
 # Application Settings
 DEBUG=True
 LOG_LEVEL=INFO
+NEXT_PUBLIC_DEV_AUTH_BYPASS=False

--- a/README.md
+++ b/README.md
@@ -117,6 +117,11 @@ OPENAI_API_KEY
 WP_API_URL, WP_USERNAME, WP_APP_PASSWORD
 POCKETFLOW_API_URL, POCKETFLOW_API_KEY
 ```
+Optional dev flag:
+```
+NEXT_PUBLIC_DEV_AUTH_BYPASS
+```
+Set to `true` to bypass dashboard authentication during local development.
 Put secrets in `.env`; it’s ignored by Git.
 
 ---

--- a/dashboard/src/middleware.ts
+++ b/dashboard/src/middleware.ts
@@ -2,7 +2,12 @@ import { NextResponse } from 'next/server';
 import type { NextRequest } from 'next/server';
 import { createMiddlewareClient } from '@supabase/auth-helpers-nextjs';
 
+const BYPASS_AUTH = process.env.NEXT_PUBLIC_DEV_AUTH_BYPASS === 'true';
+
 export async function middleware(request: NextRequest) {
+  if (BYPASS_AUTH) {
+    return NextResponse.next();
+  }
   const response = NextResponse.next();
   const supabase = createMiddlewareClient({ req: request, res: response });
 

--- a/tests/unit/test_dashboard_auth.py
+++ b/tests/unit/test_dashboard_auth.py
@@ -10,6 +10,7 @@ class TestDashboardAuth(unittest.TestCase):
             content = f.read()
         self.assertIn('createMiddlewareClient', content)
         self.assertIn("'/login'", content)
+        self.assertIn('DEV_AUTH_BYPASS', content)
 
     def test_settings_link_restricted(self):
         path = os.path.join('dashboard', 'src', 'app', 'layout.tsx')


### PR DESCRIPTION
## Summary
- allow dashboard auth bypass when `NEXT_PUBLIC_DEV_AUTH_BYPASS` is true
- document the new env variable in README and `.env.example`
- test for auth bypass flag presence in middleware

## Testing
- `./run_tests.sh` *(fails: could not install dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_687e4add186c8325a8e5ece37cd0fb9a