### PR TITLE
Use util slugify for slug creation

### DIFF
--- a/agents/shared/utils.py
+++ b/agents/shared/utils.py
@@ -18,7 +18,7 @@ import openai
 import requests
 import tiktoken
 from dotenv import load_dotenv
-from slugify import slugify
+from slugify import slugify as _slugify
 from supabase import Client, create_client
 from tenacity import retry, stop_after_attempt, wait_exponential
 
@@ -125,13 +125,18 @@ def count_tokens(text: str, model: str = "gpt-4") -> int:
 
 
 # Text processing utilities
+def slugify(text: str) -> str:
+    """Convert text to a URL-friendly slug."""
+    return _slugify(text)
+
+
 def create_slug(text: str) -> str:
     """
     Create a URL-friendly slug from text.
-    
+
     Args:
         text: Text to convert to slug
-        
+
     Returns:
         str: URL-friendly slug
     """

--- a/enhanced_seo_agent.py
+++ b/enhanced_seo_agent.py
@@ -19,6 +19,8 @@ from dotenv import load_dotenv
 from supabase import create_client
 import openai
 
+from agents.shared.utils import slugify
+
 # ANSI colors
 GREEN = "\033[92m"
 RED = "\033[91m"
@@ -269,7 +271,7 @@ def save_results_to_database(supabase, plan_id: str, keywords: Dict[str, Any], c
             content_piece = {
                 "strategic_plan_id": plan_id,
                 "title": idea["title"],
-                "slug": idea["title"].lower().replace(" ", "-"),
+                "slug": slugify(idea["title"]),
                 "status": "draft",
                 "draft_text": idea["description"]
             }

--- a/tests/unit/test_slugify_utils.py
+++ b/tests/unit/test_slugify_utils.py
@@ -1,0 +1,17 @@
+import unittest
+
+from agents.shared import utils
+
+
+class TestSlugifyUtils(unittest.TestCase):
+    def test_slugify_removes_punctuation(self):
+        title = "Hello, World! This is a Test."
+        self.assertEqual(utils.slugify(title), "hello-world-this-is-a-test")
+
+    def test_slugify_handles_special_chars(self):
+        title = "Python & Django @ Scale"
+        self.assertEqual(utils.slugify(title), "python-django-scale")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- use `slugify` util when generating slugs in `enhanced_seo_agent`
- expose `slugify` helper in `agents.shared.utils`
- test slugify with punctuation & special characters

## Testing
- `bash run_tests.sh` *(fails: Could not install dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_687e716684c48325ba3a2257ad1d8138