### PR TITLE
Fix docs for Supabase env var

### DIFF
--- a/dashboard/README.md
+++ b/dashboard/README.md
@@ -43,7 +43,7 @@ cp .env.local.example .env.local
 
 ```
 NEXT_PUBLIC_SUPABASE_URL=https://your-project.supabase.co
-NEXT_PUBLIC_SUPABASE_ANON_KEY=public-anon-key
+NEXT_PUBLIC_SUPABASE_KEY=public-anon-key
 ```
 
 2. (Optional) For CI / container deploys you may also add


### PR DESCRIPTION
## Summary
- clarify correct env var for Supabase anon key

## Testing
- `./run_tests.sh` *(fails: unable to install dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_688281c701ac8325933895068f169476